### PR TITLE
Fix abort: make message name match method

### DIFF
--- a/src/main/scala/cromwell/backend/model/TaskStatus.scala
+++ b/src/main/scala/cromwell/backend/model/TaskStatus.scala
@@ -14,7 +14,7 @@ case object RunningTaskStatus extends NonTerminalTaskStatus
 
 sealed trait TerminalTaskStatus extends TaskStatus
 final case class SucceededTaskStatus(outputs: Map[String, WdlValue], returnCode: Int, hash: ExecutionHash) extends TerminalTaskStatus
-case object CanceledTaskStatus extends TerminalTaskStatus
+case object StoppedTaskStatus extends TerminalTaskStatus
 
 sealed trait FailedTaskStatus extends TerminalTaskStatus
 final case class FailedWithoutReturnCodeTaskStatus(error: Throwable) extends FailedTaskStatus

--- a/src/main/scala/cromwell/backend/provider/local/LocalBackendActor.scala
+++ b/src/main/scala/cromwell/backend/provider/local/LocalBackendActor.scala
@@ -100,7 +100,7 @@ class LocalBackendActor(task: TaskDescriptor) extends BackendActor with StrictLo
     */
   override def stop(): Unit = {
     processAbortFunc.get.apply()
-    notifySubscribers(CanceledTaskStatus)
+    notifySubscribers(StoppedTaskStatus)
   }
 
   /**


### PR DESCRIPTION
Not much to see in the backend piece of this @gauravs90 @Horneth 
